### PR TITLE
add to google cloud oss with file content

### DIFF
--- a/service/component/oss/mocks/oss.go
+++ b/service/component/oss/mocks/oss.go
@@ -29,6 +29,10 @@ func (t *FakeOSSClient) UploadObjectFromFile(_ *orm.Engine, bucket, localFile st
 	return t.Called(bucket, localFile).Get(0).(oss.Object)
 }
 
+func (t *FakeOSSClient) UploadObjectFromContent(_ *orm.Engine, bucket string, content []byte, extension string) oss.Object {
+	return t.Called(bucket, content, extension).Get(0).(oss.Object)
+}
+
 func (t *FakeOSSClient) UploadObjectFromBase64(_ *orm.Engine, bucket, content, extension string) oss.Object {
 	return t.Called(bucket, content, extension).Get(0).(oss.Object)
 }

--- a/service/component/oss/oss.go
+++ b/service/component/oss/oss.go
@@ -10,6 +10,7 @@ type Client interface {
 	GetObjectURL(bucket string, object *Object) string
 	GetObjectCachedURL(bucket string, object *Object) string
 	GetObjectSignedURL(bucket string, object *Object, expires time.Time) string
+	UploadObjectFromContent(ormService *orm.Engine, bucket, content []byte, extension string) Object
 	UploadObjectFromFile(ormService *orm.Engine, bucket, localFile string) Object
 	UploadObjectFromBase64(ormService *orm.Engine, bucket, content, extension string) Object
 	UploadImageFromFile(ormService *orm.Engine, bucket, localFile string) Object

--- a/service/component/oss/storage/google.go
+++ b/service/component/oss/storage/google.go
@@ -97,6 +97,12 @@ func (ossStorage *GoogleOSS) GetObjectSignedURL(bucket string, object *oss.Objec
 	return signedURL
 }
 
+func (ossStorage *GoogleOSS) UploadObjectFromContent(ormService *orm.Engine, bucket string, content []byte, extension string) oss.Object {
+	ossStorage.checkBucket(bucket)
+
+	return ossStorage.putObject(ormService, bucket, content, extension)
+}
+
 func (ossStorage *GoogleOSS) UploadObjectFromFile(ormService *orm.Engine, bucket, localFile string) oss.Object {
 	ossStorage.checkBucket(bucket)
 


### PR DESCRIPTION
With this method , u can upload to google cloud directly when you're a receiving a regular POST request for file upload in gin. 
U won't need to store it in temporary location first