### PR TITLE
add create context without rest or graphql

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -18,7 +18,7 @@ func createContextMyApp(t *testing.T, projectName string, resolvers graphql.Exec
 		registry.ServiceDefinitionOrmEngineForContext(false),
 	}
 
-	return test.CreateContext(t,
+	return test.CreateAPIContext(t,
 		projectName,
 		resolvers,
 		nil,


### PR DESCRIPTION
change `CreateContext` - > `CreateAPIContext`
and added `CreateContext` to be used for places like cron or model , when you don't want (gin or graphql)