### PR TITLE
add callback function to change graphql server config

### DIFF
--- a/example/server.go
+++ b/example/server.go
@@ -34,5 +34,5 @@ func main() {
 	s.RunServer(9999, generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}), func(ginEngine *gin.Engine) {
 		exampleMiddleware.Router(ginEngine)
 		middleware.Cors(ginEngine)
-	})
+	}, nil)
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -164,7 +164,7 @@ func CreateAPIContext(t *testing.T, projectName string, resolvers graphql.Execut
 
 		testSpringInstance, deferFunc = hitrix.New(projectName, "").RegisterDIService(append(defaultServices, mockServices...)...).Build()
 		defer deferFunc()
-		ginTestInstance = hitrix.InitGin(resolvers, ginInitHandler)
+		ginTestInstance = hitrix.InitGin(resolvers, ginInitHandler, nil)
 
 		var has bool
 		ormService, has = service.DI().OrmEngine()
@@ -196,7 +196,7 @@ func CreateAPIContext(t *testing.T, projectName string, resolvers graphql.Execut
 	if len(mockServices) != 0 {
 		testSpringInstance, deferFunc = hitrix.New(projectName, "").RegisterDIService(append(defaultServices, mockServices...)...).Build()
 		defer deferFunc()
-		ginTestInstance = hitrix.InitGin(resolvers, ginInitHandler)
+		ginTestInstance = hitrix.InitGin(resolvers, ginInitHandler, nil)
 
 		// TODO: fix multiple connections to mysql
 		ormService, _ = service.DI().OrmEngine()

--- a/server.go
+++ b/server.go
@@ -25,14 +25,14 @@ type Hitrix struct {
 	exit   chan int
 }
 
-func (h *Hitrix) RunServer(defaultPort uint, server graphql.ExecutableSchema, ginInitHandler GinInitHandler) {
+func (h *Hitrix) RunServer(defaultPort uint, server graphql.ExecutableSchema, ginInitHandler GinInitHandler, gqlServerInitHandler GQLServerInitHandler) {
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = fmt.Sprintf("%d", defaultPort)
 	}
 	srv := &http.Server{
 		Addr:    ":" + port,
-		Handler: InitGin(server, ginInitHandler),
+		Handler: InitGin(server, ginInitHandler, gqlServerInitHandler),
 	}
 
 	h.preDeploy()


### PR DESCRIPTION
The reason behind this change is that i wanted to add multipart support to graphql and it could be done by the following

```
h.AddTransport(transport.MultipartForm{
		MaxMemory:     32 * mb,
		MaxUploadSize: 50 * mb,
})
```
and since there was no way to add it to the current setup , and the confiugration was project specific, I thought maybe adding a callback function will solve the probelm.

	