### PR TITLE
Add Path to graphqlparser errors

### DIFF
--- a/pkg/test/graphql-parser/error.go
+++ b/pkg/test/graphql-parser/error.go
@@ -2,6 +2,7 @@ package graphqlparser
 
 type Errors []struct {
 	Message   string
+	Path      []string
 	Locations []struct {
 		Line   int
 		Column int


### PR DESCRIPTION
In some rare cases, error message is not helpful and not showing the field name
In those cases, Path can be helpful and contains the field name