### PR TITLE
Prevent unnecessary error in tests

### DIFF
--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -284,7 +284,7 @@ func getParallelID() string {
 func dropTables(dbService *beeorm.DB) error {
 	var query string
 	rows, deferF := dbService.Query(
-		"SELECT CONCAT('DROP TABLE ',table_schema,'.',table_name,';') AS query " +
+		"SELECT CONCAT('DROP TABLE IF EXISTS ',table_schema,'.',table_name,';') AS query " +
 			"FROM information_schema.tables WHERE table_schema IN ('" + dbService.GetPoolConfig().GetDatabase() + "')",
 	)
 	defer deferF()


### PR DESCRIPTION
Usually when running tests offline, it shows errors regarding to dropping tables that are already dropped. It can be prevented