### PR TITLE
added Sender.GetTemplateKeyFromConfig() + lint fixes

### DIFF
--- a/service/component/mail/mailjet_sender.go
+++ b/service/component/mail/mailjet_sender.go
@@ -58,6 +58,16 @@ func NewMailjet(configService config.IConfig) (Sender, error) {
 	return &Mailjet{client: mailjetAPI, defaultFromEmail: fromEmail, fromName: fromName, sandboxMode: sandboxMode}, nil
 }
 
+func (s *Mailjet) GetTemplateKeyFromConfig(configService config.IConfig, templateName string) (string, error) {
+	configPath := fmt.Sprintf("mail.mailjet.templates.%s", templateName)
+
+	templateKey, ok := configService.String(configPath)
+	if !ok {
+		return "", fmt.Errorf("could not find email template key in config: %s", configPath)
+	}
+
+	return templateKey, nil
+}
 func (s *Mailjet) SendTemplate(ormService *beeorm.Engine, message *Message) error {
 	return s.sendTemplate(
 		ormService,

--- a/service/component/mail/mandrill_sender.go
+++ b/service/component/mail/mandrill_sender.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/latolukasz/beeorm"
@@ -49,6 +50,17 @@ func NewMandrill(configService config.IConfig) (Sender, error) {
 	}
 
 	return &Mandrill{client: mandrillAPI, defaultFromEmail: fromEmail, fromName: fromName}, nil
+}
+
+func (s *Mandrill) GetTemplateKeyFromConfig(configService config.IConfig, templateName string) (string, error) {
+	configPath := fmt.Sprintf("mail.mandrill.templates.%s", templateName)
+
+	templateKey, ok := configService.String(configPath)
+	if !ok {
+		return "", fmt.Errorf("could not find email template key in config: %s", configPath)
+	}
+
+	return templateKey, nil
 }
 
 func (s *Mandrill) SendTemplate(ormService *beeorm.Engine, message *Message) error {

--- a/service/component/mail/mocks/sender.go
+++ b/service/component/mail/mocks/sender.go
@@ -4,6 +4,7 @@ import (
 	"github.com/latolukasz/beeorm"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/coretrix/hitrix/service/component/config"
 	"github.com/coretrix/hitrix/service/component/mail"
 )
 
@@ -11,6 +12,11 @@ type Sender struct {
 	mock.Mock
 }
 
+func (m *Sender) GetTemplateKeyFromConfig(_ config.IConfig, templateName string) (string, error) {
+	args := m.Called(templateName)
+
+	return args.Get(1).(string), args.Error(1)
+}
 func (m *Sender) SendTemplate(_ *beeorm.Engine, message *mail.Message) error {
 	return m.Called(message.To).Error(0)
 }

--- a/service/component/mail/sender.go
+++ b/service/component/mail/sender.go
@@ -9,6 +9,7 @@ import (
 type NewSenderFunc func(configService config.IConfig) (Sender, error)
 
 type Sender interface {
+	GetTemplateKeyFromConfig(configService config.IConfig, templateName string) (string, error)
 	SendTemplate(ormService *beeorm.Engine, message *Message) error
 	SendTemplateAsync(ormService *beeorm.Engine, message *Message) error
 	SendTemplateWithAttachments(ormService *beeorm.Engine, message *MessageAttachment) error

--- a/service/registry/error_logger.go
+++ b/service/registry/error_logger.go
@@ -15,8 +15,8 @@ func ServiceProviderErrorLogger() *service.DefinitionGlobal {
 	return &service.DefinitionGlobal{
 		Name: service.ErrorLoggerService,
 		Build: func(ctn di.Container) (interface{}, error) {
-			var sentryService sentry.ISentry = nil
-			var slackAPIService slack.Slack = nil
+			var sentryService sentry.ISentry
+			var slackAPIService slack.Slack
 
 			sentryServiceInterface, err := ctn.SafeGet(service.SentryService)
 			if err == nil {


### PR DESCRIPTION
Since Mandrill uses user-defined template names, but MailJet uses random generated template names (that need to be in the saved in app config after creating the template), this PR enables better dynamic switching between Mail Providers. The added `Sender.GetTemplateKeyFromConfig()` lets users get the template key dynamically from config without knowing which Sender Provider is going to be configured on runtime. 
This prevents the use of the hard coded template name config paths in code

ex: instead of 
```go
	templateName := configService.MustString("mail.mandrill.templates.admin_user_invite")
```

we will use 
```go
mailService.GetTemplateKeyFromConfig("admin_user_invite")
```
which switches between "mail.**mandrill**.templates.admin_user_invite" and "mail.**mailjet**.templates.admin_user_invite".